### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/johanmalm/jgmenu/issues
+Bug-Submit: https://github.com/johanmalm/jgmenu/issues/new
+Repository: https://github.com/johanmalm/jgmenu.git
+Repository-Browse: https://github.com/johanmalm/jgmenu


### PR DESCRIPTION

Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/jgmenu/b7abde50-4110-46fd-9aa8-e4c014f80e4b.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0a/90efb0076ad246eca8fa53353983b10e9c769a.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/4b/52acd54e6aaa506ed79b97ff3abb26e6026c78.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/60/cd8e6cc06a5f87f1ef6ee191f87fb802b5864f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/88/9479c39d0f0ea85c30e2e4e58f53d69549c79e.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/8a/63fc60537e9392de08a5ebeae8c1e3a21f521f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/9c/8094f042e6c1cec66c2cc3b2b4104e2cbdd855.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ae/8df3565805245ff092310ba63cdc6a5763fdef.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/af/0e2801436d1e5a83f15b9bc4512113c090e4a9.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b7/3cc4ad47eca72dc790433828608b6f119b7a96.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/03/bc783ffe6a8688a753ab91926e6b3b74a1a069.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/22/62ebf0f3e45de2a52a3c23641587082a741202.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3f/632b02e738c582602fd4601cbab2feec090b8f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/7a/e3a63c17a78a949a033981ed9cbb0eb844cde8.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/96/d9efe611d14002e93a9a82c2a15dc5cb2cfd2b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a6/a6edd99f2123ff0a4db9d3164a22af9ece4daa.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ce/222174037b527e06fa6cb5ab02c87b946078ed.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/de/2f6873d804338892f223b7d752cad8648e1288.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ec/47952abce439201044d773892b28deb736e629.debug

No differences were encountered between the control files of package \*\*jgmenu\*\*
### Control files of package jgmenu-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-03bc783ffe6a8688a753ab91926e6b3b74a1a069 2262ebf0f3e45de2a52a3c23641587082a741202 3f632b02e738c582602fd4601cbab2feec090b8f 7ae3a63c17a78a949a033981ed9cbb0eb844cde8 96d9efe611d14002e93a9a82c2a15dc5cb2cfd2b a6a6edd99f2123ff0a4db9d3164a22af9ece4daa ce222174037b527e06fa6cb5ab02c87b946078ed de2f6873d804338892f223b7d752cad8648e1288 ec47952abce439201044d773892b28deb736e629-] {+0a90efb0076ad246eca8fa53353983b10e9c769a 4b52acd54e6aaa506ed79b97ff3abb26e6026c78 60cd8e6cc06a5f87f1ef6ee191f87fb802b5864f 889479c39d0f0ea85c30e2e4e58f53d69549c79e 8a63fc60537e9392de08a5ebeae8c1e3a21f521f 9c8094f042e6c1cec66c2cc3b2b4104e2cbdd855 ae8df3565805245ff092310ba63cdc6a5763fdef af0e2801436d1e5a83f15b9bc4512113c090e4a9 b73cc4ad47eca72dc790433828608b6f119b7a96+}

No differences were encountered between the control files of package \*\*jgmenu-xfce4-panel-applet\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b7abde50-4110-46fd-9aa8-e4c014f80e4b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b7abde50-4110-46fd-9aa8-e4c014f80e4b/diffoscope)).
